### PR TITLE
Comment by Steve Wilkes on naming-things-is-hard-namespace-interface-class-method-context

### DIFF
--- a/_data/comments/naming-things-is-hard-namespace-interface-class-method-context/7663bccd.yml
+++ b/_data/comments/naming-things-is-hard-namespace-interface-class-method-context/7663bccd.yml
@@ -1,0 +1,14 @@
+id: 7663bccd
+date: 2020-05-04T08:00:24.6877144Z
+name: Steve Wilkes
+email: 
+avatar: https://github.com/stevewilkes.png
+url: 
+message: >-
+  Intellisense is easier to use without the prefix because with it you have to type out 'c u s t o m e r' before you get to the characters which actually differentiate the properties.
+
+
+  Also (and this is a tiny point, but it's a real one) if it's 'Id' instead of 'CustomerId' then Customer can trivially implement an IEntity { Id } interface (or something like that) if that were to ever come in handy.
+
+
+  Glad you found it useful in any case :)


### PR DESCRIPTION
avatar: <img src="https://github.com/stevewilkes.png" />

Intellisense is easier to use without the prefix because with it you have to type out 'c u s t o m e r' before you get to the characters which actually differentiate the properties.

Also (and this is a tiny point, but it's a real one) if it's 'Id' instead of 'CustomerId' then Customer can trivially implement an IEntity { Id } interface (or something like that) if that were to ever come in handy.

Glad you found it useful in any case :)